### PR TITLE
Fix intersection observer

### DIFF
--- a/alwaysontop/render.js
+++ b/alwaysontop/render.js
@@ -215,18 +215,9 @@ class AlwaysOnTop extends EventEmitter {
      * @param {IntersectionObserver} observer
      */
     _onIntersection(entries) {
-        const singleEntry = entries.pop();
-        this._jitsiMeetElectronWindow.removeListener(
-            'focus',
-            this._hideAlwaysOnTopWindow
-        );
-
-        if (singleEntry.isIntersecting) {
+        const isTargetVisible = entries.length > 0 && entries[entries.length - 1].isIntersecting;
+        if (isTargetVisible) {
             this._hideAlwaysOnTopWindow();
-            this._jitsiMeetElectronWindow.on(
-                'focus',
-                this._hideAlwaysOnTopWindow
-            );
         } else {
             this._openAlwaysOnTopWindow();
         }

--- a/alwaysontop/render.js
+++ b/alwaysontop/render.js
@@ -217,8 +217,10 @@ class AlwaysOnTop extends EventEmitter {
     _onIntersection(entries) {
         const isTargetVisible = entries.length > 0 && entries[entries.length - 1].isIntersecting;
         if (isTargetVisible) {
+            this._isMeetingFocused = true;
             this._hideAlwaysOnTopWindow();
         } else {
+            this._isMeetingFocused = false;
             this._openAlwaysOnTopWindow();
         }
     }
@@ -355,8 +357,8 @@ class AlwaysOnTop extends EventEmitter {
      *
      * @returns {void}
      */
-    _openAlwaysOnTopWindow() {
-        if (this._alwaysOnTopWindow) {
+    _openAlwaysOnTopWindow(event) {
+        if (this._alwaysOnTopWindow && (event || !this._isMeetingFocused)) {
             this._showAlwaysOnTopWindow();
             return;
         }
@@ -425,7 +427,7 @@ class AlwaysOnTop extends EventEmitter {
      * @returns {void}
      */
     _hideAlwaysOnTopWindow() {
-      if (exists(this._alwaysOnTopBrowserWindow)) {
+      if (exists(this._alwaysOnTopBrowserWindow) && this._isMeetingFocused) {
         try {
           this._alwaysOnTopBrowserWindow.hide();
         } catch (ignoreDestroyedRaceConditionError) {}


### PR DESCRIPTION
Intersection observer introduces the following issues:
- removes 'focus' listener when the meeting frame is removed by navigating inside the app
- issues occur when focus listeners are added/removed while the frame becomes visible/invisible
- removes entries from the array passed as param